### PR TITLE
Admin inv item info

### DIFF
--- a/app/controllers/admin/invoices_controller.rb
+++ b/app/controllers/admin/invoices_controller.rb
@@ -6,6 +6,5 @@ class Admin::InvoicesController < ApplicationController
   def show
     @invoice = Invoice.find(params[:id])
     @customer = Customer.find(@invoice.customer_id)
-    require "pry"; binding.pry
   end
 end

--- a/app/controllers/admin/invoices_controller.rb
+++ b/app/controllers/admin/invoices_controller.rb
@@ -6,5 +6,6 @@ class Admin::InvoicesController < ApplicationController
   def show
     @invoice = Invoice.find(params[:id])
     @customer = Customer.find(@invoice.customer_id)
+    require "pry"; binding.pry
   end
 end

--- a/app/views/admin/invoices/show.html.erb
+++ b/app/views/admin/invoices/show.html.erb
@@ -4,13 +4,17 @@
 <p><b>Status:</b> <%= @invoice.status %></p>
 <p><b>Created At:</b> <%= @invoice.created_at.strftime('%A, %b %d, %Y') %></p>
 <p><b>Customer:</b> <%= @customer.first_name %> <%= @customer.last_name %></p>
+<br>
 
 <h3>Invoice Items:</h3>
 <% @invoice.invoice_items.each do |invoice_item| %>
   <div id="invoice_item-<%= invoice_item.id %>">
-  <p><b>Item Name:</b> <% %></p>
-  <p><b>Quantity:</b> <%= invoice_item.quantity %></p>
-  <p><b>Unit Price:</b> $<%= invoice_item.unit_price %></p>
-  <p><b>Status:</b> <%= invoice_item.status %></p>
+    <p><b>Item Name:</b> <% @invoice.items.each do |item| %>
+                           <%= item.name if item.id == invoice_item.item_id %>
+                         <% end %></p>
+    <p>Quantity: <%= invoice_item.quantity %></p>
+    <p>Unit Price: $<%= (invoice_item.unit_price/100).to_f.round(2) %></p>
+    <p>Status: <%= invoice_item.status %></p>
+    <br>
   </div>
 <% end %>

--- a/app/views/admin/invoices/show.html.erb
+++ b/app/views/admin/invoices/show.html.erb
@@ -8,7 +8,7 @@
 <h3>Invoice Items:</h3>
 <% @invoice.invoice_items.each do |invoice_item| %>
   <div id="invoice_item-<%= invoice_item.id %>">
-  <p><b>Item Name:</b> </p>
+  <p><b>Item Name:</b> <% %></p>
   <p><b>Quantity:</b> <%= invoice_item.quantity %></p>
   <p><b>Unit Price:</b> $<%= invoice_item.unit_price %></p>
   <p><b>Status:</b> <%= invoice_item.status %></p>

--- a/app/views/admin/invoices/show.html.erb
+++ b/app/views/admin/invoices/show.html.erb
@@ -4,3 +4,13 @@
 <p><b>Status:</b> <%= @invoice.status %></p>
 <p><b>Created At:</b> <%= @invoice.created_at.strftime('%A, %b %d, %Y') %></p>
 <p><b>Customer:</b> <%= @customer.first_name %> <%= @customer.last_name %></p>
+
+<h3>Invoice Items:</h3>
+<% @invoice.invoice_items.each do |invoice_item| %>
+  <div id="invoice_item-<%= invoice_item.id %>">
+  <p><b>Item Name:</b> </p>
+  <p><b>Quantity:</b> <%= invoice_item.quantity %></p>
+  <p><b>Unit Price:</b> $<%= invoice_item.unit_price %></p>
+  <p><b>Status:</b> <%= invoice_item.status %></p>
+  </div>
+<% end %>

--- a/spec/features/admin/invoices/show_spec.rb
+++ b/spec/features/admin/invoices/show_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe 'Admin Invoice Show Page' do
     visit admin_invoice_path("#{@invoice1.id}")
 
     within("#invoice_item-#{@invoice_item1.id}") do
-      # expect(page).to have_content("#{@item1.name}")
+      expect(page).to have_content("#{@item1.name}")
       expect(page).to have_content("#{@invoice_item1.quantity}")
       expect(page).to have_content("#{@invoice_item1.unit_price}")
       expect(page).to have_content("#{@invoice_item1.status}")

--- a/spec/features/admin/invoices/show_spec.rb
+++ b/spec/features/admin/invoices/show_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'Admin Invoice Show Page' do
   # - Customer first and last name
   it 'shows an invoice with attributes' do
     visit admin_invoice_path("#{@invoice1.id}")
-    
+
     expect(page).to have_content("#{@invoice1.id}")
     expect(page).to have_content("#{@invoice1.status}")
     expect(page).to have_content("#{@invoice1.created_at.strftime('%A, %b %d, %Y')}")
@@ -21,5 +21,40 @@ RSpec.describe 'Admin Invoice Show Page' do
     expect(page).to_not have_content("#{@invoice8.status}")
     expect(page).to_not have_content("#{@customer2.first_name}")
     expect(page).to_not have_content("#{@customer2.last_name}")
+  end
+
+  # As an admin
+  # When I visit an admin invoice show page
+  # Then I see all of the items on the invoice including:
+  # - Item name
+  # - The quantity of the item ordered
+  # - The price the Item sold for
+  # - The Invoice Item status
+  it 'shows all items on the invoice' do
+    invoice_item2 = InvoiceItem.create!(invoice_id: @invoice1.id, item_id: @item2.id, quantity: 50, unit_price: @item2.unit_price, status: 'shipped')
+    invoice_item3 = InvoiceItem.create!(invoice_id: @invoice1.id, item_id: @item3.id, quantity: 25, unit_price: @item3.unit_price, status: 'shipped')
+
+    visit admin_invoice_path("#{@invoice1.id}")
+
+    within("div#invoice_item1") do
+      expect(page).to have_content("#{@item1.name}")
+      expect(page).to have_content("#{@invoice_item1.quantity}")
+      expect(page).to have_content("#{@invoice_item1.unit_price}")
+      expect(page).to have_content("#{@invoice_item1.status}")
+    end
+
+    within("div#invoice_item2") do
+      expect(page).to have_content("#{@item2.name}")
+      expect(page).to have_content("#{invoice_item2.quantity}")
+      expect(page).to have_content("#{invoice_item2.unit_price}")
+      expect(page).to have_content("#{invoice_item2.status}")
+    end
+
+    within("div#invoice_item3") do
+      expect(page).to have_content("#{@item3.name}")
+      expect(page).to have_content("#{invoice_item3.quantity}")
+      expect(page).to have_content("#{invoice_item3.unit_price}")
+      expect(page).to have_content("#{invoice_item3.status}")
+    end
   end
 end

--- a/spec/features/admin/invoices/show_spec.rb
+++ b/spec/features/admin/invoices/show_spec.rb
@@ -36,22 +36,22 @@ RSpec.describe 'Admin Invoice Show Page' do
 
     visit admin_invoice_path("#{@invoice1.id}")
 
-    within("div#invoice_item1") do
-      expect(page).to have_content("#{@item1.name}")
+    within("#invoice_item-#{@invoice_item1.id}") do
+      # expect(page).to have_content("#{@item1.name}")
       expect(page).to have_content("#{@invoice_item1.quantity}")
       expect(page).to have_content("#{@invoice_item1.unit_price}")
       expect(page).to have_content("#{@invoice_item1.status}")
     end
 
-    within("div#invoice_item2") do
-      expect(page).to have_content("#{@item2.name}")
+    within("#invoice_item-#{invoice_item2.id}") do
+      # expect(page).to have_content("#{@item2.name}")
       expect(page).to have_content("#{invoice_item2.quantity}")
       expect(page).to have_content("#{invoice_item2.unit_price}")
       expect(page).to have_content("#{invoice_item2.status}")
     end
 
-    within("div#invoice_item3") do
-      expect(page).to have_content("#{@item3.name}")
+    within("#invoice_item-#{invoice_item3.id}") do
+      # expect(page).to have_content("#{@item3.name}")
       expect(page).to have_content("#{invoice_item3.quantity}")
       expect(page).to have_content("#{invoice_item3.unit_price}")
       expect(page).to have_content("#{invoice_item3.status}")

--- a/spec/features/admin/invoices/show_spec.rb
+++ b/spec/features/admin/invoices/show_spec.rb
@@ -39,21 +39,21 @@ RSpec.describe 'Admin Invoice Show Page' do
     within("#invoice_item-#{@invoice_item1.id}") do
       expect(page).to have_content("#{@item1.name}")
       expect(page).to have_content("#{@invoice_item1.quantity}")
-      expect(page).to have_content("#{@invoice_item1.unit_price}")
+      expect(page).to have_content("#{(@invoice_item1.unit_price/100).to_f.round(2)}")
       expect(page).to have_content("#{@invoice_item1.status}")
     end
 
     within("#invoice_item-#{invoice_item2.id}") do
-      # expect(page).to have_content("#{@item2.name}")
+      expect(page).to have_content("#{@item2.name}")
       expect(page).to have_content("#{invoice_item2.quantity}")
-      expect(page).to have_content("#{invoice_item2.unit_price}")
+      expect(page).to have_content("#{(invoice_item2.unit_price/100).to_f.round(2)}")
       expect(page).to have_content("#{invoice_item2.status}")
     end
 
     within("#invoice_item-#{invoice_item3.id}") do
-      # expect(page).to have_content("#{@item3.name}")
+      expect(page).to have_content("#{@item3.name}")
       expect(page).to have_content("#{invoice_item3.quantity}")
-      expect(page).to have_content("#{invoice_item3.unit_price}")
+      expect(page).to have_content("#{(invoice_item3.unit_price/100).to_f.round(2)}")
       expect(page).to have_content("#{invoice_item3.status}")
     end
   end


### PR DESCRIPTION
What I Did:
- Admin Invoice Show Page: add Invoice_Item information

Roadblocks:
- Item name associated with invoice item
- Had to iterate a second time using @invoice.items and pull item by comparing item.id to invoice.item_id

Tests:
- All written tests pass
- Simplecov at  97.49% due to csv_load_helper

Notes:
- Need to refactor unit price on show page to show two zeros following decimal
- Moving on to total revenue