### PR TITLE
Got the bug where when we a merchant doesnt have a bulk discount it still calculates the total revenue without a discount on it.

### DIFF
--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -30,7 +30,9 @@ class Merchant < ApplicationRecord
 
     discounted_revenue = 0
     merchant_invoice_items.each do |item|
-      if item.quantity >= self.quantity_threshold
+      if self.quantity_threshold == nil
+        discounted_revenue += (item.quantity * item.unit_price)
+      elsif item.quantity >= self.quantity_threshold
         discounted_revenue += ((item.quantity * item.unit_price) - ((item.quantity * item.unit_price) * (self.maximum_discount(item.quantity))))
       else
         discounted_revenue += (item.quantity * item.unit_price)

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -193,12 +193,15 @@ RSpec.describe Merchant, type: :model do
     end
 
     describe '#total_discount_revenue' do
-      it 'can calculate the total discount revenue' do
+      it 'can calculate the total discount revenue when it reaches the threshold and when it does not' do
         @merchant8 = Merchant.create!(name: "Best Buy", status: "enabled")
+        @merchant9 = Merchant.create!(name: "Comcast", status: "enabled")
+        @merchant10 = Merchant.create!(name: "Excel", status: "enabled")
+
 
         @bulk_discount7 = BulkDiscount.create!(percentage_discount: 0.2, quantity_threshold: 100, merchant_id: @merchant8.id)
         @bulk_discount8 = BulkDiscount.create!(percentage_discount: 0.3, quantity_threshold: 200, merchant_id: @merchant8.id)
-        # @bulk_discount9 = BulkDiscount.create!(percentage_discount: 0.15, quantity_threshold: 200, merchant_id: @merchant8.id)
+        @bulk_discount9 = BulkDiscount.create!(percentage_discount: 0.15, quantity_threshold: 500, merchant_id: @merchant9.id)
 
         @customer11 = Customer.create!(first_name: "Caleb", last_name: "Wittman")
 
@@ -206,16 +209,21 @@ RSpec.describe Merchant, type: :model do
         @invoice101 = Invoice.create!(status: 'completed', customer_id: @customer11.id)
         @invoice102 = Invoice.create!(status: 'completed', customer_id: @customer11.id)
         @invoice103 = Invoice.create!(status: 'in_progress', customer_id: @customer11.id)
-
+        @invoice104 = Invoice.create!(status: 'completed', customer_id: @customer11.id)
+        @invoice105 = Invoice.create!(status: 'completed', customer_id: @customer11.id)
 
         @transaction100 = Transaction.create!(credit_card_number: '1234234534564567', credit_card_expiration_date: nil, result: true, invoice_id: @invoice100.id)
         @transaction101 = Transaction.create!(credit_card_number: '1234234534564567', credit_card_expiration_date: nil, result: true, invoice_id: @invoice101.id)
         @transaction102 = Transaction.create!(credit_card_number: '1234234534564567', credit_card_expiration_date: nil, result: true, invoice_id: @invoice102.id)
         @transaction103 = Transaction.create!(credit_card_number: '1234234534564567', credit_card_expiration_date: nil, result: false, invoice_id: @invoice103.id)
+        @transaction104 = Transaction.create!(credit_card_number: '1234234534564567', credit_card_expiration_date: nil, result: false, invoice_id: @invoice104.id)
+        @transaction105 = Transaction.create!(credit_card_number: '1234234534564567', credit_card_expiration_date: nil, result: false, invoice_id: @invoice105.id)
 
         @item18 = Item.create!(name: 'Big T.V.', description: 'Big TV', unit_price: 800, merchant_id: @merchant8.id)
         @item19 = Item.create!(name: 'Bigger T.V.', description: 'Bigger TV', unit_price: 1200, merchant_id: @merchant8.id)
         @item20 = Item.create!(name: 'T.V.', description: 'TV', unit_price: 400, merchant_id: @merchant8.id)
+        @item21 = Item.create!(name: 'Biggest T.V.', description: 'Biggest TV', unit_price: 1800, merchant_id: @merchant9.id)
+        @item22 = Item.create!(name: 'Da HEAT', description: 'Da Heat', unit_price: 4000, merchant_id: @merchant10.id)
 
 
         
@@ -225,8 +233,58 @@ RSpec.describe Merchant, type: :model do
         @invoice_item25 = InvoiceItem.create!(invoice_id: @invoice103.id, item_id: @item18.id, quantity: 50, unit_price: @item18.unit_price, status: 'shipped')
         @invoice_item26 = InvoiceItem.create!(invoice_id: @invoice100.id, item_id: @item19.id, quantity: 90, unit_price: @item19.unit_price, status: 'shipped')
         @invoice_item27 = InvoiceItem.create!(invoice_id: @invoice101.id, item_id: @item20.id, quantity: 130, unit_price: @item20.unit_price, status: 'shipped')
+        @invoice_item28 = InvoiceItem.create!(invoice_id: @invoice104.id, item_id: @item21.id, quantity: 100, unit_price: @item21.unit_price, status: 'shipped')
+        @invoice_item29 = InvoiceItem.create!(invoice_id: @invoice105.id, item_id: @item22.id, quantity: 200, unit_price: @item22.unit_price, status: 'shipped')
+
 
         expect(@merchant8.total_discount_revenue(@invoice100.id)).to eq(188000)
+        expect(@merchant9.total_discount_revenue(@invoice104.id)).to eq(180000)
+      end
+
+      it 'can calculate the total discount revenue when it does not have a bulk discount associated' do
+        @merchant8 = Merchant.create!(name: "Best Buy", status: "enabled")
+        @merchant9 = Merchant.create!(name: "Comcast", status: "enabled")
+        @merchant10 = Merchant.create!(name: "Excel", status: "enabled")
+
+
+        @bulk_discount7 = BulkDiscount.create!(percentage_discount: 0.2, quantity_threshold: 100, merchant_id: @merchant8.id)
+        @bulk_discount8 = BulkDiscount.create!(percentage_discount: 0.3, quantity_threshold: 200, merchant_id: @merchant8.id)
+        @bulk_discount9 = BulkDiscount.create!(percentage_discount: 0.15, quantity_threshold: 500, merchant_id: @merchant9.id)
+
+        @customer11 = Customer.create!(first_name: "Caleb", last_name: "Wittman")
+
+        @invoice100 = Invoice.create!(status: 'completed', customer_id: @customer11.id)
+        @invoice101 = Invoice.create!(status: 'completed', customer_id: @customer11.id)
+        @invoice102 = Invoice.create!(status: 'completed', customer_id: @customer11.id)
+        @invoice103 = Invoice.create!(status: 'in_progress', customer_id: @customer11.id)
+        @invoice104 = Invoice.create!(status: 'completed', customer_id: @customer11.id)
+        @invoice105 = Invoice.create!(status: 'completed', customer_id: @customer11.id)
+
+        @transaction100 = Transaction.create!(credit_card_number: '1234234534564567', credit_card_expiration_date: nil, result: true, invoice_id: @invoice100.id)
+        @transaction101 = Transaction.create!(credit_card_number: '1234234534564567', credit_card_expiration_date: nil, result: true, invoice_id: @invoice101.id)
+        @transaction102 = Transaction.create!(credit_card_number: '1234234534564567', credit_card_expiration_date: nil, result: true, invoice_id: @invoice102.id)
+        @transaction103 = Transaction.create!(credit_card_number: '1234234534564567', credit_card_expiration_date: nil, result: false, invoice_id: @invoice103.id)
+        @transaction104 = Transaction.create!(credit_card_number: '1234234534564567', credit_card_expiration_date: nil, result: false, invoice_id: @invoice104.id)
+        @transaction105 = Transaction.create!(credit_card_number: '1234234534564567', credit_card_expiration_date: nil, result: false, invoice_id: @invoice105.id)
+
+        @item18 = Item.create!(name: 'Big T.V.', description: 'Big TV', unit_price: 800, merchant_id: @merchant8.id)
+        @item19 = Item.create!(name: 'Bigger T.V.', description: 'Bigger TV', unit_price: 1200, merchant_id: @merchant8.id)
+        @item20 = Item.create!(name: 'T.V.', description: 'TV', unit_price: 400, merchant_id: @merchant8.id)
+        @item21 = Item.create!(name: 'Biggest T.V.', description: 'Biggest TV', unit_price: 1800, merchant_id: @merchant9.id)
+        @item22 = Item.create!(name: 'Da HEAT', description: 'Da Heat', unit_price: 4000, merchant_id: @merchant10.id)
+
+
+        
+        @invoice_item22 = InvoiceItem.create!(invoice_id: @invoice100.id, item_id: @item18.id, quantity: 125, unit_price: @item18.unit_price, status: 'shipped')
+        @invoice_item23 = InvoiceItem.create!(invoice_id: @invoice101.id, item_id: @item19.id, quantity: 200, unit_price: @item19.unit_price, status: 'shipped')
+        @invoice_item24 = InvoiceItem.create!(invoice_id: @invoice102.id, item_id: @item20.id, quantity: 99, unit_price: @item20.unit_price, status: 'shipped')
+        @invoice_item25 = InvoiceItem.create!(invoice_id: @invoice103.id, item_id: @item18.id, quantity: 50, unit_price: @item18.unit_price, status: 'shipped')
+        @invoice_item26 = InvoiceItem.create!(invoice_id: @invoice100.id, item_id: @item19.id, quantity: 90, unit_price: @item19.unit_price, status: 'shipped')
+        @invoice_item27 = InvoiceItem.create!(invoice_id: @invoice101.id, item_id: @item20.id, quantity: 130, unit_price: @item20.unit_price, status: 'shipped')
+        @invoice_item28 = InvoiceItem.create!(invoice_id: @invoice104.id, item_id: @item21.id, quantity: 100, unit_price: @item21.unit_price, status: 'shipped')
+        @invoice_item29 = InvoiceItem.create!(invoice_id: @invoice105.id, item_id: @item22.id, quantity: 200, unit_price: @item22.unit_price, status: 'shipped')
+
+        expect(@merchant10.total_discount_revenue(@invoice105.id)).to eq(800000)
       end
     end
   end


### PR DESCRIPTION
There was a bug earlier when the merchant doesn't have a bulk discount associated with it that it will error out and say can't compare a nil value. Fixed it with more of a conditional to get that through. Now it calculates the total discount revenue as the same as the total revenue. All new integrated code is tested and 100% covered.